### PR TITLE
added missing menutext for joint and workcell commands

### DIFF
--- a/freecad/cross/ui/command_new_joint.py
+++ b/freecad/cross/ui/command_new_joint.py
@@ -13,6 +13,7 @@ class _NewJointCommand:
 
     def GetResources(self):
         return {'Pixmap': 'joint.svg',
+                'MenuText': tr('Create a Joint'),
                 'Accel': 'N, J',
                 'ToolTip': tr('Create a Joint.')}
 

--- a/freecad/cross/ui/command_new_workcell.py
+++ b/freecad/cross/ui/command_new_workcell.py
@@ -10,6 +10,7 @@ class _NewWorkcellCommand:
 
     def GetResources(self):
         return {'Pixmap': 'workcell.svg',
+                'MenuText': tr('Create a Workcell'),
                 'Accel': 'N, W',
                 'ToolTip': tr('Create a Workcell.')}
 

--- a/freecad/cross/ui/command_wb_settings.py
+++ b/freecad/cross/ui/command_wb_settings.py
@@ -22,6 +22,7 @@ class _WbSettingsCommand:
 
     def GetResources(self):
         return {'Pixmap': 'wb_settings.svg',
+                'MenuText': tr('Workbench settings'),
                 'Accel': 'W, S',
                 'ToolTip': tr('Workbench settings')}
 


### PR DESCRIPTION
the menu texts of `Create a Joint` and `Create a workcell` are missing