### PR TITLE
Add cylindrical collision tool.

### DIFF
--- a/freecad/cross/init_gui.py
+++ b/freecad/cross/init_gui.py
@@ -17,6 +17,7 @@ from .ui import command_set_joints
 from .ui import command_set_placement
 from .ui import command_simplify_mesh
 from .ui import command_sphere_from_bounding_box
+from .ui import command_cylinder_from_bounding_box
 from .ui import command_update_planning_scene
 from .ui import command_urdf_export
 from .ui import command_wb_settings
@@ -48,6 +49,7 @@ class CrossWorkbench(fcgui.Workbench):
             'NewXacroObject',  # Defined in ./ui/command_new_xacro_object.py.
             'BoxFromBoundingBox',  # Defined in ./ui/command_box_from_bounding_box.py.
             'SphereFromBoundingBox',  # Defined in ./ui/command_sphere_from_bounding_box.py.
+            'CylinderFromBoundingBox',  # Defined in ./ui/command_cylinder_from_bounding_box.py.
             'SimplifyMesh',  # Defined in ./ui/command_simplify_mesh.py.
             'UrdfImport',  # Defined in ./ui/command_robot_from_urdf.py.
             'AssemblyFromUrdf',  # Defined in ./ui/command_assembly_from_urdf.py.

--- a/freecad/cross/ui/command_cylinder_from_bounding_box.py
+++ b/freecad/cross/ui/command_cylinder_from_bounding_box.py
@@ -1,0 +1,76 @@
+import FreeCAD as fc
+import FreeCADGui as fcgui
+
+from ..freecad_utils import error
+from ..freecad_utils import strip_subelement
+from ..freecad_utils import warn
+from ..gui_utils import tr
+from ..placement_utils import get_global_placement
+
+
+class CylinderFromBoundingBoxCommand:
+    def GetResources(self):
+        return {'Pixmap': 'sphere_from_bbox.svg',
+                'MenuText': tr('Cylinder from bounding box'),
+                'ToolTip': tr('Add a Part::Cylinder corresponding to the'
+                              ' bounding box of the selected objects'),
+                }
+
+    def Activated(self):
+        is_one_object_compatible = False
+        is_one_object_incompatible = False
+        selection = fcgui.Selection.getSelectionEx('', 0)
+        if not selection:
+            # Should not happen.
+            return
+        for selection_object in selection:
+            obj = selection_object.Object
+            if selection_object.HasSubObjects:
+                # Inside a part.
+                subpath = selection_object.SubElementNames[0]
+                try:
+                    subobj_origin = obj.getSubObjectList(subpath)[-1]
+                    subobj = subobj_origin.getPropertyOfGeometry()
+                except AttributeError:
+                    is_one_object_incompatible = True
+                    continue
+                placement = get_global_placement(obj, subpath)
+                # Cancel the rotation because bounding boxes are axis-aligned.
+                placement.Rotation = fc.Rotation()
+                box_name = obj.Label + '.' + strip_subelement(subpath) + '_bbox'
+            else:
+                # Outside of any part.
+                try:
+                    subobj = obj.getPropertyOfGeometry()
+                except AttributeError:
+                    is_one_object_incompatible = True
+                    continue
+                box_name = obj.Label + '_bbox'
+                placement = fc.Placement()
+            # Cf. https://github.com/pboechat/pyobb for oriented bounding-box.
+            is_one_object_compatible = True
+            doc = fc.activeDocument()
+            bbox = subobj.BoundBox
+            doc.openTransaction(tr('Cylinder from bounding box'))
+            cylinder = doc.addObject('Part::Cylinder', box_name)
+            cylinder.Label = box_name
+            cylinder.Height = bbox.ZLength
+            cylinder.Radius = bbox.DiagonalLength / 2.0
+            # correction FeatureBase offset (it placed in middle of height by some reason)
+            try:
+                if subobj_origin.TypeId == 'PartDesign::FeatureBase':
+                    cylinder.Placement.Base.z = - (bbox.ZLength / 2)
+            except (NameError, AttributeError):
+                continue
+            cylinder.Placement = placement * cylinder.Placement
+            doc.commitTransaction()
+        if not is_one_object_compatible:
+            error(tr('No compatible object selected'), gui=True)
+        if is_one_object_incompatible:
+            warn(tr('One or more incompatible object selected'), gui=True)
+
+    def IsActive(self):
+        return bool(fcgui.Selection.getSelection())
+
+
+fcgui.addCommand('CylinderFromBoundingBox', CylinderFromBoundingBoxCommand())

--- a/freecad/cross/ui/command_cylinder_from_bounding_box.py
+++ b/freecad/cross/ui/command_cylinder_from_bounding_box.py
@@ -29,8 +29,8 @@ class CylinderFromBoundingBoxCommand:
                 # Inside a part.
                 subpath = selection_object.SubElementNames[0]
                 try:
-                    subobj_origin = obj.getSubObjectList(subpath)[-1]
-                    subobj = subobj_origin.getPropertyOfGeometry()
+                    subobj_source = obj.getSubObjectList(subpath)[-1]
+                    subobj = subobj_source.getPropertyOfGeometry()
                 except AttributeError:
                     is_one_object_incompatible = True
                     continue
@@ -56,9 +56,9 @@ class CylinderFromBoundingBoxCommand:
             cylinder.Label = box_name
             cylinder.Height = bbox.ZLength
             cylinder.Radius = bbox.DiagonalLength / 2.0
-            # correction FeatureBase offset (it placed in middle of height by some reason)
+            # correction FeatureBase offset (bottom edge placed in middle of height by some reason)
             try:
-                if subobj_origin.TypeId == 'PartDesign::FeatureBase':
+                if subobj_source.TypeId == 'PartDesign::FeatureBase':
                     cylinder.Placement.Base.z = - (bbox.ZLength / 2)
             except (NameError, AttributeError):
                 continue

--- a/freecad/cross/ui/command_cylinder_from_bounding_box.py
+++ b/freecad/cross/ui/command_cylinder_from_bounding_box.py
@@ -29,8 +29,7 @@ class CylinderFromBoundingBoxCommand:
                 # Inside a part.
                 subpath = selection_object.SubElementNames[0]
                 try:
-                    subobj_source = obj.getSubObjectList(subpath)[-1]
-                    subobj = subobj_source.getPropertyOfGeometry()
+                    subobj = obj.getSubObjectList(subpath)[-1].getPropertyOfGeometry()
                 except AttributeError:
                     is_one_object_incompatible = True
                     continue
@@ -56,12 +55,6 @@ class CylinderFromBoundingBoxCommand:
             cylinder.Label = box_name
             cylinder.Height = bbox.ZLength
             cylinder.Radius = bbox.DiagonalLength / 2.0
-            # correction FeatureBase offset (bottom edge placed in middle of height by some reason)
-            try:
-                if subobj_source.TypeId == 'PartDesign::FeatureBase':
-                    cylinder.Placement.Base.z = - (bbox.ZLength / 2)
-            except (NameError, AttributeError):
-                continue
             cylinder.Placement = placement * cylinder.Placement
             doc.commitTransaction()
         if not is_one_object_compatible:


### PR DESCRIPTION
Necessary for rotating links.
 
Usage examples:
![cylinder3](https://github.com/galou/freecad.cross/assets/13005708/5f15e39a-f6f3-4514-8197-5d425ac51e84)

![cylinder2](https://github.com/galou/freecad.cross/assets/13005708/a1434673-c53e-442e-8c4f-95725f9235b6)

It will nice if you make custom icon for cylinder.