### PR TITLE
Add unicode support for filenames

### DIFF
--- a/freecad/cross/utils.py
+++ b/freecad/cross/utils.py
@@ -17,7 +17,7 @@ import re
 
 import FreeCAD as fc
 
-INVALID_FILENAME_CHARS = re.compile(r'[^A-Za-z0-9_\-.]+')
+INVALID_FILENAME_CHARS = re.compile(r'[^\w.\-]+')
 
 # Stubs and type hints.
 DO = fc.DocumentObject


### PR DESCRIPTION
This regexp will accept unicode chars in filenames. I am not sure if it is a good idea in general but you asked.